### PR TITLE
Add user put and post endpoints for neo4j

### DIFF
--- a/metadata_service/api/__init__.py
+++ b/metadata_service/api/__init__.py
@@ -2,11 +2,40 @@ import logging
 from http import HTTPStatus
 from typing import Iterable, Union, Mapping, Any, Optional, List
 
+from flask import request
 from flask_restful import Resource
 
+from metadata_service.exception import NotFoundException
 from metadata_service.proxy import BaseProxy
+from marshmallow import UnmarshalResult, ValidationError
 
 LOGGER = logging.getLogger(__name__)
+
+
+def produce_not_found_response(slug: str, exception: Exception) -> tuple:
+    """
+    Returns Not Found status with message containing slug that was not found.
+    Logs exception that prompted this response.
+
+    :param exception:
+    :param slug:
+    :return: Tuple with message containing slug that was not found and NOT_FOUND status
+    """
+    msg = f'slug {slug} does not exist'
+    LOGGER.exception(f'Not Found error caused by: {exception}')
+    return {'message': msg}, HTTPStatus.NOT_FOUND
+
+
+def produce_internal_server_error_response(exception: Exception) -> tuple:
+    """
+    Returns Internal Server Error status and logs exception that caused the
+    error
+
+    :param exception: Any exception can be bubbled up here
+    :return: Tuple with opaque error message and INTERNAL_SERVER_ERROR status
+    """
+    LOGGER.exception(f'Internal server error caused by: {exception}')
+    return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class BaseAPI(Resource):
@@ -15,6 +44,62 @@ class BaseAPI(Resource):
         self.client = client
         self.str_type = str_type
         self.allow_empty_upload = False
+
+    def post(self) -> Iterable[Union[List, Mapping, int, None]]:
+        post_objects = getattr(self.client, f'post_{self.str_type}s')
+        """
+        Inserts or updates objects
+        """
+        try:
+            json_data = request.get_json()
+            data = None
+            if json_data is None:
+                if not self.allow_empty_upload:
+                    return {'message': 'No input data provided'}, HTTPStatus.BAD_REQUEST
+            else:
+                # Validate and deserialize input
+                try:
+                    schema = self.schema(many=True, strict=True)
+                    result: UnmarshalResult = schema.load(json_data)
+                    data = result.data
+                except ValidationError as err:
+                    return {'messages': err.messages}, HTTPStatus.UNPROCESSABLE_ENTITY
+            post_result: Any = post_objects(data=data)
+
+            return post_result, HTTPStatus.OK
+
+        except Exception as e:
+            return produce_internal_server_error_response(e)
+
+    # TODO: refactor to actually use this id in PUTs
+    def put(self, *, id: str = '') -> Iterable[Union[Mapping, int, None]]:
+        put_object = getattr(self.client, f'put_{self.str_type}')
+        """
+        Inserts or updates a single object
+        """
+        try:
+            json_data = request.get_json()
+            data = None
+            if json_data is None:
+                if not self.allow_empty_upload:
+                    return {'message': 'No input data provided'}, HTTPStatus.BAD_REQUEST
+            else:
+                # Validate and deserialize input
+                try:
+                    schema = self.schema(strict=True)
+                    result: UnmarshalResult = schema.load(json_data)
+                    data = result.data
+                except ValidationError as err:
+                    return {'messages': err.messages}, HTTPStatus.UNPROCESSABLE_ENTITY
+            put_object(data=data)
+
+            return None, HTTPStatus.OK
+
+        except NotFoundException as e:
+            return produce_not_found_response(id, e)
+
+        except Exception as e:
+            return produce_internal_server_error_response(e)
 
     def get(self, *, id: Optional[str] = None) -> Iterable[Union[Mapping, int, None]]:
         """

--- a/metadata_service/api/swagger_doc/user/detail_post.yml
+++ b/metadata_service/api/swagger_doc/user/detail_post.yml
@@ -1,0 +1,17 @@
+Posts user details
+---
+tags:
+  - 'user'
+responses:
+  200:
+    description: 'Successfully posted user details'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/MessageResponse'
+  500:
+    description: 'Internal Server Error'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata_service/api/swagger_doc/user/detail_put.yml
+++ b/metadata_service/api/swagger_doc/user/detail_put.yml
@@ -1,0 +1,30 @@
+Puts the user details
+---
+tags:
+  - 'user'
+parameters:
+  - name: id
+    in: path
+    example: 'roald9@example.org'
+    type: string
+    schema:
+      type: string
+responses:
+  200:
+    description: 'Successfully put user details'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/MessageResponse'
+  404:
+    description: 'User not found'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+  500:
+    description: 'Internal Server Error'
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -1,6 +1,6 @@
 import logging
 from http import HTTPStatus
-from typing import Iterable, Mapping, Optional, Union
+from typing import Iterable, List, Mapping, Optional, Union
 
 from flask_restful import Resource, fields, marshal
 from flasgger import swag_from
@@ -46,6 +46,14 @@ class UserDetailAPI(BaseAPI):
     @swag_from('swagger_doc/user/detail_get.yml')
     def get(self, *, id: Optional[str] = None) -> Iterable[Union[Mapping, int, None]]:
         return super().get(id=id)
+
+    @swag_from('swagger_doc/user/detail_put.yml')
+    def put(self, *, id: str = '') -> Iterable[Union[Mapping, int, None]]:
+        return super().put(id=id)
+
+    @swag_from('swagger_doc/user/detail_post.yml')
+    def post(self) -> Iterable[Union[List, Mapping, int, None]]:
+        return super().post()
 
 
 class UserFollowsAPI(Resource):

--- a/tests/unit/api/test_user.py
+++ b/tests/unit/api/test_user.py
@@ -28,6 +28,22 @@ class UserDetailAPITest(unittest.TestCase):
         self.assertEqual(list(response)[1], HTTPStatus.OK)
         self.mock_client.get_users.assert_called_once()
 
+    @mock.patch('metadata_service.api.request')
+    def test_post(self, mock_request: MagicMock) -> None:
+        mock_request.get_json.return_value = [dict(email='username@example.com', is_active=True)]
+        self.mock_client.post_users.return_value = {}
+        response = self.api.post()
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        self.mock_client.post_users.assert_called_once()
+
+    @mock.patch('metadata_service.api.request')
+    def test_put(self, mock_request: MagicMock) -> None:
+        mock_request.get_json.return_value = dict(email='username@example.com', is_active=True)
+        self.mock_client.put_user.return_value = {}
+        response = self.api.put(id='username')
+        self.assertEqual(list(response)[1], HTTPStatus.OK)
+        self.mock_client.put_user.assert_called_once()
+
 
 class UserFollowsAPITest(unittest.TestCase):
 

--- a/tests/unit/proxy/test_statsd_utilities.py
+++ b/tests/unit/proxy/test_statsd_utilities.py
@@ -45,9 +45,22 @@ class TestStatsdUtilities(unittest.TestCase):
             self.assertEqual(mock_statsd_init.call_count, 2)
 
     def test_with_neo4j_proxy(self) -> None:
-        with patch.object(GraphDatabase, 'driver'), \
+        with patch.object(GraphDatabase, 'driver') as mock_driver, \
                 patch.object(Neo4jProxy, '_execute_cypher_query'), \
                 patch.object(statsd_utilities, '_get_statsd_client') as mock_statsd_client:
+
+            mock_session = MagicMock()
+            mock_driver.return_value.session.return_value = mock_session
+            mock_transaction = MagicMock()
+            mock_session.begin_transaction.return_value = mock_transaction
+
+            mock_run = MagicMock()
+            mock_transaction.run = mock_run
+            mock_record = MagicMock()
+            mock_record.get.return_value = 1
+            mock_run.return_value.data.return_value = [mock_record]
+            mock_commit = MagicMock()
+            mock_transaction.commit = mock_commit
 
             mock_success_incr = MagicMock()
             mock_statsd_client.return_value.incr = mock_success_incr


### PR DESCRIPTION
### Summary of Changes

This PR adds PUT and POST endpoints for `/users`. It makes use of the common BaseAPI. I also added a `LocalTransaction` class, which can be used to DRY up existing linking and upsert code as follow up. 

I tested these endpoints out manually like:
```
curl -X POST http://0.0.0.0:5002/user -H "Content-Type: application/json" -d '[{"email": "y@gmail.com"}]'
curl -X PUT http://0.0.0.0:5002/user -H "Content-Type: application/json" -d '{"email": "xxx@gmail.com"}'
```

### Tests
I added tests for the put_user and post_users methods for the neo4j_proxy. I also added tests for the put and post on the UserDetailAPI

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
