### PR TITLE
chore: fix docker push action

### DIFF
--- a/.github/workflows/pypipublish.yml
+++ b/.github/workflows/pypipublish.yml
@@ -33,10 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Login with docker
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.8
-        with:
-          name: amundsen-io/amundsenmetadatalibrary
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_names: true
+        if: success()
+        run: make build-push-image


### PR DESCRIPTION
Signed-off-by: feng-tao <fengtao04@gmail.com>

### Summary of Changes

The current docker push action doesn't work. We could also change the docker file to match the github action requirement if this pr doesn't work.

