### PR TITLE
feat: Add Watermark entries for partitioned tables in AtlasProxy

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -79,6 +79,10 @@ class Config:
     # List of regexes which will exclude certain parameters from appearing as Programmatic Descriptions
     PROGRAMMATIC_DESCRIPTIONS_EXCLUDE_FILTERS = []  # type: list
 
+    # List of accepted date formats for AtlasProxy Watermarks. With this we allow more than one datetime partition
+    # format to be used in tables
+    WATERMARK_DATE_FORMATS = ['%Y%m%d']
+
 
 # NB: If you're using the gremlin proxy, the appropriate GremlinConfig must be added to any other configs
 class LocalConfig(LocalGremlinConfig, Config):

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -94,6 +94,44 @@ class Data:
         }
     }
 
+    partition_entity_1 = {
+        'typeName': 'table_partition',
+        'status': 'INACTIVE',
+        'attributes': {
+            'name': '20200908'
+        },
+        'createTime': 1599723564000
+    }
+
+    partition_entity_2 = {
+        'typeName': 'table_partition',
+        'status': 'ACTIVE',
+        'attributes': {
+            'name': '20200909'
+        },
+        'createTime': 1599723564000
+    }
+
+    partition_entity_3 = {
+        'typeName': 'table_partition',
+        'status': 'ACTIVE',
+        'attributes': {
+            'name': '20200910'
+        },
+        'createTime': 1599723564000
+    }
+
+    partition_entity_4 = {
+        'typeName': 'table_partition',
+        'status': 'ACTIVE',
+        'attributes': {
+            'name': '2020,8'
+        },
+        'createTime': 1599723564000
+    }
+
+    partitions = [partition_entity_1, partition_entity_2, partition_entity_3, partition_entity_4]
+
     entity1 = {
         'guid': '1',
         'typeName': entity_type,
@@ -129,6 +167,32 @@ class Data:
                     "relationshipStatus": "DELETED",
                     "guid": "111",
                     "displayText": "deleted_owned_by"
+                }
+            ],
+            'partitions': [
+                {
+                    "entityStatus": "INACTIVE",
+                    "relationshipStatus": "ACTIVE",
+                    "guid": "000",
+                    "displayText": "active_partition"
+                },
+                {
+                    "entityStatus": "ACTIVE",
+                    "relationshipStatus": "ACTIVE",
+                    "guid": "111",
+                    "displayText": "active_partition"
+                },
+                {
+                    "entityStatus": "ACTIVE",
+                    "relationshipStatus": "ACTIVE",
+                    "guid": "222",
+                    "displayText": "active_partition"
+                },
+                {
+                    "entityStatus": "ACTIVE",
+                    "relationshipStatus": "ACTIVE",
+                    "guid": "333",
+                    "displayText": "active_partition"
                 }
             ]
         },


### PR DESCRIPTION
Signed-off-by: mgorsk1 <gorskimariusz13@gmail.com>

### Summary of Changes

When a Table entry contains `partitions` entries, we should verify if these partitions are time based. And if so - Watermark objects (low/high) should be created and added to Table object. 

The assumption is that `name` of partition contains only partition value and we can parse this value to match one of the expected date formats (configured with WATERMARK_DATE_FORMATS option). Another assumption is that date format is consistent throughout all partitions of table.

### Tests

Added tests with `partition` entities

### Documentation

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
