### PR TITLE
fix: data_type as Column.col_type.

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -360,7 +360,7 @@ class AtlasProxy(BaseProxy):
                 Column(
                     name=col_attrs.get('name'),
                     description=col_attrs.get('description') or col_attrs.get('comment'),
-                    col_type=col_attrs.get('type') or col_attrs.get('dataType'),
+                    col_type=col_attrs.get('type') or col_attrs.get('dataType') or col_attrs.get('data_type'),
                     sort_order=col_attrs.get('position') or 9999,
                     stats=statistics,
                 )


### PR DESCRIPTION
The lastest version of Atlas has a predefined type [rdbms_column](https://github.com/apache/atlas/blob/master/addons/models/2000-RDBMS/2010-rdbms_model.json#L169), which is assigned as a sub type of Column by [amundsenatlastypes](https://github.com/dwarszawski/amundsen-atlas-types). It has a attribute called "data_type" that is equivalent to Column.col_type.
