### PR TITLE
fix: Add /delete bidirectional relations in case of owner

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -552,8 +552,11 @@ class Neo4jProxy(BaseProxy):
         :return:
         """
         delete_query = textwrap.dedent("""
-        MATCH (n1:User{key: $user_email})-[r1:OWNER_OF]->(n2:Table {key: $tbl_key})-[r2:OWNER]->(n1) DELETE r1,r2
-        """)
+                MATCH (n1:User{key: $user_email}), (n2:Table {key: $tbl_key})
+                OPTIONAL MATCH (n1)-[r1:OWNER_OF]->(n2)
+                OPTIONAL MATCH (n2)-[r2:OWNER]->(n1) 
+                DELETE r1,r2
+                """)
 
         try:
             tx = self._driver.session().begin_transaction()

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -546,7 +546,6 @@ class Neo4jProxy(BaseProxy):
                      owner: str) -> None:
         """
         Delete the owner / owned_by relationship.
-
         :param table_uri:
         :param owner:
         :return:
@@ -557,7 +556,6 @@ class Neo4jProxy(BaseProxy):
         OPTIONAL MATCH (n2)-[r2:OWNER]->(n1) 
         DELETE r1,r2
         """)
-        
         try:
             tx = self._driver.session().begin_transaction()
             tx.run(delete_query, {'user_email': owner,

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -960,7 +960,8 @@ class Neo4jProxy(BaseProxy):
         if relation_type == UserResourceRel.follow:
             relation = f'(usr{user_matcher})-[rel:FOLLOW]->(resource{resource_matcher})'
         elif relation_type == UserResourceRel.own:
-            relation = f'(resource{resource_matcher})-[r1:OWNER]->(usr{user_matcher})-[r2:OWNER_OF]->(resource{resource_matcher})'
+            relation = f'(resource{resource_matcher})-[r1:OWNER]->(usr{user_matcher})-[r2:OWNER_OF]->' \
+                       f'(resource{resource_matcher})'
         elif relation_type == UserResourceRel.read:
             relation = f'(usr{user_matcher})-[rel:READ]->(resource{resource_matcher})'
         else:

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -552,12 +552,12 @@ class Neo4jProxy(BaseProxy):
         :return:
         """
         delete_query = textwrap.dedent("""
-                MATCH (n1:User{key: $user_email}), (n2:Table {key: $tbl_key})
-                OPTIONAL MATCH (n1)-[r1:OWNER_OF]->(n2)
-                OPTIONAL MATCH (n2)-[r2:OWNER]->(n1) 
-                DELETE r1,r2
-                """)
-
+        MATCH (n1:User{key: $user_email}), (n2:Table {key: $tbl_key})
+        OPTIONAL MATCH (n1)-[r1:OWNER_OF]->(n2)
+        OPTIONAL MATCH (n2)-[r2:OWNER]->(n1) 
+        DELETE r1,r2
+        """)
+        
         try:
             tx = self._driver.session().begin_transaction()
             tx.run(delete_query, {'user_email': owner,

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -553,7 +553,7 @@ class Neo4jProxy(BaseProxy):
         delete_query = textwrap.dedent("""
         MATCH (n1:User{key: $user_email}), (n2:Table {key: $tbl_key})
         OPTIONAL MATCH (n1)-[r1:OWNER_OF]->(n2)
-        OPTIONAL MATCH (n2)-[r2:OWNER]->(n1) 
+        OPTIONAL MATCH (n2)-[r2:OWNER]->(n1)
         DELETE r1,r2
         """)
         try:

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -977,7 +977,7 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(resource:Table {key: $resource_key})-[r1:OWNER]->(usr:USER {key: $user_key})-[r2:OWNER_OF]->(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:OWNER]->(usr:User {key: $user_key})-[r2:OWNER_OF]->(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.follow,

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -977,7 +977,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(resource:Table {key: $resource_key})-[r1:OWNER]->(usr:User {key: $user_key})-[r2:OWNER_OF]->(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:OWNER]->(usr:User {key: $user_key})-[r2:OWNER_OF]->' \
+                       '(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.follow,

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -963,8 +963,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(resource:Table {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-[r2:FOLLOW]->' \
-                       '(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-' \
+                       '[r2:FOLLOW]->(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.read,
@@ -987,8 +987,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Dashboard)
-            expected = '(resource:Dashboard {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-[r2:FOLLOW]->' \
-                       '(resource:Dashboard {key: $resource_key})'
+            expected = '(resource:Dashboard {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-' \
+                       '[r2:FOLLOW]->(resource:Dashboard {key: $resource_key})'
             self.assertEqual(expected, actual)
 
 

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -977,7 +977,7 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(usr:User {key: $user_key})<-[rel:OWNER]-(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:OWNER]->(usr:USER {key: $user_key})-[r2:OWNER_OF]->(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.follow,

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -963,14 +963,16 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(usr:User {key: $user_key})-[rel:FOLLOW]->(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-[r2:FOLLOW]->' \
+                       '(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.read,
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Table)
-            expected = '(usr:User {key: $user_key})-[rel:READ]->(resource:Table {key: $resource_key})'
+            expected = '(resource:Table {key: $resource_key})-[r1:READ_BY]->(usr:User {key: $user_key})-[r2:READ]->' \
+                       '(resource:Table {key: $resource_key})'
             self.assertEqual(expected, actual)
 
             actual = neo4j_proxy._get_user_resource_relationship_clause(UserResourceRel.own,
@@ -985,7 +987,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                                         id='foo',
                                                                         user_key='bar',
                                                                         resource_type=ResourceType.Dashboard)
-            expected = '(usr:User {key: $user_key})-[rel:FOLLOW]->(resource:Dashboard {key: $resource_key})'
+            expected = '(resource:Dashboard {key: $resource_key})-[r1:FOLLOWED_BY]->(usr:User {key: $user_key})-[r2:FOLLOW]->' \
+                       '(resource:Dashboard {key: $resource_key})'
             self.assertEqual(expected, actual)
 
 


### PR DESCRIPTION
Signed-off-by: dikshathakur3119 <dikshathakur@lyft.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes
Added Bidirectional relation to add/delete in case of user and owner relationship
When we add or delete an `OWNER` relation from UI, it only deletes one way relation whereas when we do it from extractor, it add bidirectional relations, which is causing some inconsistency in neo4j graph, and creating duplicate `OWNER_OF` relations. To make this consistent, bidirectional owner relations will be created by UI API as well.
 
### Tests
No new tests added

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
