### PR TITLE
fix: Too many partitions in one Atlas query (Watermarks in Atlas Proxy)

### DIFF
--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -169,32 +169,9 @@ class Data:
                     "displayText": "deleted_owned_by"
                 }
             ],
-            'partitions': [
-                {
-                    "entityStatus": "INACTIVE",
-                    "relationshipStatus": "ACTIVE",
-                    "guid": "000",
-                    "displayText": "active_partition"
-                },
-                {
-                    "entityStatus": "ACTIVE",
-                    "relationshipStatus": "ACTIVE",
-                    "guid": "111",
-                    "displayText": "active_partition"
-                },
-                {
-                    "entityStatus": "ACTIVE",
-                    "relationshipStatus": "ACTIVE",
-                    "guid": "222",
-                    "displayText": "active_partition"
-                },
-                {
-                    "entityStatus": "ACTIVE",
-                    "relationshipStatus": "ACTIVE",
-                    "guid": "333",
-                    "displayText": "active_partition"
-                }
-            ]
+            'partitions': [dict(displayText=p.get('attributes').get('name'),
+                                entityStatus=p.get('status'),
+                                relationshipStatus='ACTIVE') for p in partitions]
         },
     }
     entity1.update(classification_entity)

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
+from typing import List, Dict
 
 
 class DottedDict(dict):
@@ -130,7 +131,7 @@ class Data:
         'createTime': 1599723564000
     }
 
-    partitions = [partition_entity_1, partition_entity_2, partition_entity_3, partition_entity_4]
+    partitions: List[Dict] = [partition_entity_1, partition_entity_2, partition_entity_3, partition_entity_4]
 
     entity1 = {
         'guid': '1',
@@ -169,7 +170,7 @@ class Data:
                     "displayText": "deleted_owned_by"
                 }
             ],
-            'partitions': [dict(displayText=p.get('attributes').get('name'),
+            'partitions': [dict(displayText=p.get('attributes', dict()).get('name'),
                                 entityStatus=p.get('status'),
                                 relationshipStatus='ACTIVE') for p in partitions]
         },


### PR DESCRIPTION
Signed-off-by: mgorsk1 <gorskimariusz13@gmail.com>

### Summary of Changes

Do not collect full partition entities and use displayText instead to get watermarks. This will be more efficient and performant approach especially with tables with a lot of partitions.

### Tests


### Documentation


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
