### PR TITLE
Update get_tags no longer return tag_count 0 tag

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -785,8 +785,10 @@ class Neo4jProxy(BaseProxy):
         # todo: Currently all the tags are default type, we could open it up if we want to include badge
         query = textwrap.dedent("""
         MATCH (t:Tag{tag_type: 'default'})
-        OPTIONAL MATCH (resource)-[:TAGGED_BY]->(t)
-        RETURN t as tag_name, count(distinct resource.key) as tag_count
+        OPTIONAL MATCH (tbl:Table)-[:TAGGED_BY]->(t)
+        WITH t as tag_name, count(distinct tbl.key) as tag_count
+        WHERE tag_count > 0
+        RETURN t as tag_name, count(distinct tbl.key) as tag_count
         """)
 
         records = self._execute_cypher_query(statement=query,


### PR DESCRIPTION
Signed-off-by: bluefa <chulyonga@gmail.com>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Make neo4j query "get_tags" no longer return "tag count 0" tag. 


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
