### PR TITLE
fix: expire is a keyword argument for beaker cache

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -819,7 +819,7 @@ class Neo4jProxy(BaseProxy):
             return None
 
     @timer_with_counter
-    @_CACHE.cache('_get_popular_tables_uris', _GET_POPULAR_TABLE_CACHE_EXPIRY_SEC)
+    @_CACHE.cache('_get_popular_tables_uris', expire=_GET_POPULAR_TABLE_CACHE_EXPIRY_SEC)
     def _get_popular_tables_uris(self, num_entries: int) -> List[str]:
         """
         Retrieve popular table uris. Will provide tables with top x popularity score.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

Change `expire` from positional argument to keyword argument.
Or cache will never be refreshed.

### Tests

Write a simple getRandNum function locally:
```
@_CACHE.cache('test', 1)
def getRandNum(input):
    return random.randint(0, 10)
```
If I treat `expire` as a positional argument, above function will always return the same value.
However, after I change it to keyword argument:
```
@_CACHE.cache('test', expire=1)
def getRandNum(input):
    return random.randint(0, 10)
```
The value will change every second.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
- [ ] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
