### PR TITLE
feat: Enable custom keyword arguments in Atlas Proxy Client

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -17,6 +17,7 @@ PROXY_PASSWORD = 'PROXY_PASSWORD'
 PROXY_ENCRYPTED = 'PROXY_ENCRYPTED'
 PROXY_VALIDATE_SSL = 'PROXY_VALIDATE_SSL'
 PROXY_CLIENT = 'PROXY_CLIENT'
+PROXY_CLIENT_KWARGS = 'PROXY_CLIENT_KWARGS'
 
 PROXY_CLIENTS = {
     'NEO4J': 'metadata_service.proxy.neo4j_proxy.Neo4jProxy',
@@ -83,6 +84,10 @@ class Config:
     # List of accepted date formats for AtlasProxy Watermarks. With this we allow more than one datetime partition
     # format to be used in tables
     WATERMARK_DATE_FORMATS = ['%Y%m%d']
+
+    # Custom kwargs that will be passed to proxy client. Can be used to fine-tune parameters like timeout
+    # or num of retries
+    PROXY_CLIENT_KWARGS: Dict = dict()
 
 
 # NB: If you're using the gremlin proxy, the appropriate GremlinConfig must be added to any other configs

--- a/metadata_service/proxy/__init__.py
+++ b/metadata_service/proxy/__init__.py
@@ -35,12 +35,15 @@ def get_proxy_client() -> BaseProxy:
             encrypted = current_app.config[config.PROXY_ENCRYPTED]
             validate_ssl = current_app.config[config.PROXY_VALIDATE_SSL]
 
+            client_kwargs = current_app.config[config.PROXY_CLIENT_KWARGS]
+
             client = import_string(current_app.config[config.PROXY_CLIENT])
             _proxy_client = client(host=host,
                                    port=port,
                                    user=user,
                                    password=password,
                                    encrypted=encrypted,
-                                   validate_ssl=validate_ssl)
+                                   validate_ssl=validate_ssl,
+                                   client_kwargs=client_kwargs)
 
     return _proxy_client

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -70,7 +70,8 @@ class AtlasProxy(BaseProxy):
                  user: str = 'admin',
                  password: str = '',
                  encrypted: bool = False,
-                 validate_ssl: bool = False) -> None:
+                 validate_ssl: bool = False,
+                 client_kwargs: dict = dict()) -> None:
         """
         Initiate the Apache Atlas client with the provided credentials
         """
@@ -80,7 +81,8 @@ class AtlasProxy(BaseProxy):
                              username=user,
                              password=password,
                              protocol=protocol,
-                             validate_ssl=validate_ssl)
+                             validate_ssl=validate_ssl,
+                             **client_kwargs)
 
     def _get_ids_from_basic_search(self, *, params: Dict) -> List[str]:
         """


### PR DESCRIPTION
### Summary of Changes

This PR adds a possibility to pass custom kwargs to Atlas proxy client. It be used to fine-tune parameters like timeout or num of retries. Since every client might accept different kind of extra parameters it might be easier to just have custom dictionary complementing 

### Tests


### Documentation


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
