### PR TITLE
fix: marshmallow deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ typing-extensions==3.7.4
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
-amundsen-common>=0.8.1
+amundsen-common>=0.8.2
 amundsen-gremlin>=0.0.7
 
 boto3==1.17.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,5 +65,5 @@ beaker>=1.10.0
 overrides==2.5
 typed-ast==1.4.2
 isort[colors]~=5.4
-marshmallow>=3.0,<=3.6
-marshmallow-annotations@git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef
+marshmallow>=2.15.3,<3.0
+marshmallow-annotations>=2.4.0,<3.0


### PR DESCRIPTION
### Summary of Changes

Reverts marshmallow upgrade until proper dependency chain can be achieved. Current state creates dep conflicts across different repos and prevents publishing to pypi. See https://github.com/amundsen-io/amundsencommon/pull/100 

### Tests

n/a

### Documentation

n/a

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
