### PR TITLE
fix: Reconcile gremlin description writes with the Databuilder

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -123,6 +123,7 @@ class NeptuneConfig(LocalGremlinConfig, LocalConfig):
     LOG_LEVEL = 'INFO'
 
     # PROXY_HOST FORMAT: wss://<NEPTUNE_URL>:<NEPTUNE_PORT>/gremlin
+    PROXY_HOST = os.environ.get('PROXY_HOST')
     PROXY_PORT = None   # type: ignore
 
     PROXY_CLIENT = PROXY_CLIENTS['NEPTUNE']

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -123,7 +123,7 @@ class NeptuneConfig(LocalGremlinConfig, LocalConfig):
     LOG_LEVEL = 'INFO'
 
     # PROXY_HOST FORMAT: wss://<NEPTUNE_URL>:<NEPTUNE_PORT>/gremlin
-    PROXY_HOST = os.environ.get('PROXY_HOST')
+    PROXY_HOST = os.environ.get('PROXY_HOST', 'localhost')
     PROXY_PORT = None   # type: ignore
 
     PROXY_CLIENT = PROXY_CLIENTS['NEPTUNE']

--- a/metadata_service/proxy/neptune_proxy.py
+++ b/metadata_service/proxy/neptune_proxy.py
@@ -13,8 +13,7 @@ from amundsen_gremlin.gremlin_model import WellKnownProperties
 from amundsen_gremlin.neptune_bulk_loader.api import (
     NeptuneBulkLoaderApi, get_neptune_graph_traversal_source_factory)
 from amundsen_gremlin.script_translator import ScriptTranslatorTargetNeptune
-from amundsen_gremlin.test_and_development_shard import (
-    _reset_for_testing_only, get_shard, shard_set_explicitly)
+from amundsen_gremlin.test_and_development_shard import get_shard
 from for_requests.assume_role_aws4auth import AssumeRoleAWS4Auth
 from for_requests.aws4auth_compatible import to_aws4_request_compatible_host
 from for_requests.host_header_ssl import HostHeaderSSLAdapter
@@ -65,10 +64,6 @@ class NeptuneGremlinProxy(AbstractGremlinProxy):
         # port should be part of that url
         if port is not None:
             raise NotImplementedError(f'port is not allowed! port={port}')
-
-        if client_kwargs.get('ignore_neptune_shard', False):
-            _reset_for_testing_only()
-            shard_set_explicitly('')
 
         # for IAM auth, we need the triplet or a Session which is more general
         if isinstance(password, boto3.session.Session):

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ typing-extensions==3.7.4
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
 amundsen-common>=0.9.0
-amundsen-gremlin>=0.0.7
+amundsen-gremlin>=0.0.9
 
 boto3==1.17.23
 flasgger==0.9.3


### PR DESCRIPTION
Signed-off-by: Andrew Ciambrone <andrjc4@vt.edu>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

- Upgrades the metadata proxy requirements so that it uses amundsengremlin 0.0.9 which changes the description key to the same as the databuilders. 

- Removed the reset shards from the neptune proxy because that has been moved to amundsengremlin in 0.0.8

- fixed the default source to be "description" instead of "user" 

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
- [x] PR adds unit tests, updates existing unit tests, **OR** documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
