### PR TITLE
Modified RuntimeError to NotFoundException in neo4j_proxy (metadata s…

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -400,7 +400,7 @@ class Neo4jProxy(BaseProxy):
                                                              'key': uri})
 
             if not result.single():
-                raise RuntimeError('Failed to update the resource {uri} description'.format(uri=uri))
+                raise NotFoundException('Failed to update the description as resource {uri} does not exist'.format(uri=uri))
 
             # end neo4j transaction
             tx.commit()
@@ -496,8 +496,8 @@ class Neo4jProxy(BaseProxy):
                                                              'column_key': column_uri})
 
             if not result.single():
-                raise RuntimeError('Failed to update the table {tbl} '
-                                   'column {col} description'.format(tbl=table_uri,
+                raise NotFoundException('Failed to update the table {tbl} '
+                                   'column {col} description as either table or column does not exist'.format(tbl=table_uri,
                                                                      col=column_uri))
 
             # end neo4j transaction


### PR DESCRIPTION
Try block in  `_put_resource_description`  & `put_column_description` method throws RuntimeError when table or column doesn’t exist. I have changed it to throw NotFoundException with 404 status code.